### PR TITLE
Updated reactjs.org repo link to Indonesian one

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The documentation is divided into several sections with a different tone and pur
 
 1. `git add -A && git commit -m "My message"` (replacing `My message` with a commit message, such as `Fixed header logo on Android`) to stage and commit your changes
 1. `git push my-fork-name the-name-of-my-branch`
-1. Go to the [reactjs.org repo](https://github.com/reactjs/reactjs.org) and you should see recently pushed branches.
+1. Go to the [id.reactjs.org repo](https://github.com/reactjs/id.reactjs.org) and you should see recently pushed branches.
 1. Follow GitHub's instructions.
 1. If possible, include screenshots of visual changes. A Netlify build will also be automatically created once you make your PR so other people can see your change.
 


### PR DESCRIPTION
The instruction in https://github.com/reactjs/id.reactjs.org#push-it section still refers to the original English repo. I changed it to current repo's (Indonesian) link.