### PR TITLE
Fix word typo "khisis" in optimizing performance content

### DIFF
--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -270,7 +270,7 @@ class CounterButton extends React.Component {
 }
 ```
 
-Dalam kode ini, `shouldComponentUpdate` hanya memeriksa jika ada perubahan dalam `props.color` atau `state.count`. Jika nilai variabel-variabel tersebut tidak berubah, komponen tidak akan diperbarui. Jika komponen Anda menjadi lebih kompleks, Anda dapat menggunakan pola serupa dengan melakukan "perbandingan dangkal" (*shallow comparison*) diantara semua nilai di dalam `props` dan `state` untuk menentukan apakah komponen harus diperbarui. Pola ini cukup umum sehingga React menyediakan *helper* khisis untuk menggunakan logika ini - tinggal melakukan *inherit* dari `React.PureComponent`. Jadi kode di bawah adalah cara lebih simpel untuk melakukan hal serupa:
+Dalam kode ini, `shouldComponentUpdate` hanya memeriksa jika ada perubahan dalam `props.color` atau `state.count`. Jika nilai variabel-variabel tersebut tidak berubah, komponen tidak akan diperbarui. Jika komponen Anda menjadi lebih kompleks, Anda dapat menggunakan pola serupa dengan melakukan "perbandingan dangkal" (*shallow comparison*) diantara semua nilai di dalam `props` dan `state` untuk menentukan apakah komponen harus diperbarui. Pola ini cukup umum sehingga React menyediakan *helper* khusus untuk menggunakan logika ini - tinggal melakukan *inherit* dari `React.PureComponent`. Jadi kode di bawah adalah cara lebih simpel untuk melakukan hal serupa:
 
 ```js
 class CounterButton extends React.PureComponent {


### PR DESCRIPTION
Hi,
recently, I read the documentation and I've found this typo word. The word "khisis" should be "khusus" right?

![image](https://user-images.githubusercontent.com/15377132/83493630-3e69ba00-a4df-11ea-82e5-053ab8baef22.png)


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
